### PR TITLE
Add marketmetrics.digital

### DIFF
--- a/lists/fraud.txt
+++ b/lists/fraud.txt
@@ -6,3 +6,4 @@
 # You should have received a copy of the license along with this
 # work. If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 
+marketmetrics.digital #1 - Target: Github SSH Keys for Handshake Airdrop


### PR DESCRIPTION
This website is used to get fraudulently gain access to old enough ssh keys used on Github in order to get more out of the Handshake Airdrop.

Source: https://twitter.com/promofaux/status/1259885330200756229
Airdrop Ref: https://github.com/handshake-org/hs-airdrop