### PR TITLE
Add Overwolf ads & tracking domains

### DIFF
--- a/lists/ads.txt
+++ b/lists/ads.txt
@@ -6,3 +6,5 @@
 # You should have received a copy of the license along with this
 # work. If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 
+analyticsnew.overwolf.com # Overwolf ads & tracking
+tracking.overwolf.com     # Overwolf ads & tracking


### PR DESCRIPTION
Overwolf runs an ad platform based on plug ins. They also offer an SDK where the customer receives real-time events from players.

Refs:
https://brands.overwolf.com/
https://overwolf.github.io/
https://advertisers.overwolf.com/

Other domains: https://crt.sh/?q=overwolf.com