### PR TITLE
Add malicious domains by the new maintainer of The Great Suspender

### DIFF
--- a/lists/malware.txt
+++ b/lists/malware.txt
@@ -1,3 +1,11 @@
 # Copyright by Intel-Data Authors
 # Managed by Safing at https://github.com/safing/intel-data
 # License: CC-BY-SA-4.0
+
+# Domains used be the malicious new maintainer of the "The Great Suspender" Browser Extension.
+# Ref: https://github.com/greatsuspender/thegreatsuspender/issues/1263
+owebanalytics.com
+trckpath.com
+static.trckpath.com
+trckingbyte.com
+static.trckingbyte.com


### PR DESCRIPTION
Someone acquired the "The Great Suspender" browser extension and just turns out to be on the malicious side. There is no statement from the new author - pure silence. Exact usage of domains is unknown, but seems to be tracking and/or malicious.

See https://github.com/greatsuspender/thegreatsuspender/issues/1263 for more details.