### PR TITLE
Disable community nodes as exits

### DIFF
--- a/spn/main-intel.yaml
+++ b/spn/main-intel.yaml
@@ -139,7 +139,7 @@ InfoOverrides:
 
 AdviseOnlyTrustedHubs: false
 AdviseOnlyTrustedHomeHubs: true
-AdviseOnlyTrustedDestinationHubs: false
+AdviseOnlyTrustedDestinationHubs: true
 
 HomeHubAdvisory:
 - "- Zwj52Q7d5ezvFk7HKB42dBtFu152bC9JasYF7BHB724RfG" # sono [NL] is too slow for home hub


### PR DESCRIPTION
We have had multiple reports of "choppy" connectivity, which started about when community nodes were advised to be used as exits again.