### PR TITLE
Add Microsoft telemetry domains

### DIFF
--- a/lists/telemetry.txt
+++ b/lists/telemetry.txt
@@ -12,8 +12,48 @@ eu.vortex-win.data.microsoft.com
 geo.settings-win.data.microsoft.com.akadns.net
 geo.vortex.data.microsoft.com.akadns.net
 oca.telemetry.microsoft.com
-settings-win.data.microsoft.com
 us.vortex-win.data.microsoft.com
 v10-win.vortex.data.microsoft.com.akadns.net
-v10.vortex-win.data.microsoft.com
 vortex-win-sandbox.data.microsoft.com
+
+#
+# The following telemetry endpoints were obtained using official Microsoft documentation.
+#
+
+# https://learn.microsoft.com/en-us/windows/privacy/manage-windows-11-endpoints
+
+settings-win.data.microsoft.com
+functional.events.data.microsoft.com
+browser.events.data.msn.com
+self.events.data.microsoft.com
+v10.events.data.microsoft.com
+telecommand.telemetry.microsoft.com
+www.telecommandsvc.microsoft.com
+
+# https://learn.microsoft.com/en-us/windows/privacy/manage-windows-20h2-endpoints
+
+v20.events.data.microsoft.com
+
+# https://learn.microsoft.com/en-us/windows/privacy/manage-windows-1903-endpoints
+
+cs11.wpc.v0cdn.net
+cs1137.wpc.gammacdn.net
+modern.watson.data.microsoft.com
+watson.telemetry.microsoft.com
+
+# https://learn.microsoft.com/en-us/windows/privacy/manage-windows-1809-endpoints
+
+cy2.vortex.data.microsoft.com.akadns.net
+v10.vortex-win.data.microsoft.com
+modern.watson.data.microsoft.com.akadns.net
+
+# https://learn.microsoft.com/en-us/windows/privacy/windows-endpoints-2004-non-enterprise-editions
+
+ris.api.iris.microsoft.com
+
+# https://learn.microsoft.com/en-us/windows/privacy/windows-endpoints-1809-non-enterprise-editions
+
+aria.microsoft.com                          # Office Telemetry
+nexusrules.officeapps.live.com              # Office Telemetry
+wpc.v0cdn.net
+iriscoremetadataprod.blob.core.windows.net


### PR DESCRIPTION
I added some Microsoft telemetry domains listed in their official documentation.
It might be worth considering adding `*.data.microsoft.com` as a catch-all, seeing that it appears to be used exclusively for telemetry.