### PR TITLE
promoted zentara to safing node and set gps location overrides

### DIFF
--- a/spn/main-intel.yaml
+++ b/spn/main-intel.yaml
@@ -217,6 +217,15 @@ Hubs:
   ZwzBf2xCd5Jcy5MwmnQcGUXZYfGj4JyJFFPZrDwgxqU9SF: # sento [US]
     Trusted: true
     VerifiedOwner: Safing
+  ZwzsJSTeqcUg3on3P4dMsR7uQsGrvMimrkaJZNv5jj87Zn: # zentara [DE]
+    Trusted: true
+    VerifiedOwner: Safing
+    Override:
+      CountryCode: DE
+      Coordinates: # Dusseldorf
+        Latitude: 51.22
+        Longitude: 6.78
+        AccuracyRadius: 20
 
   # CoinFund.app
   Zwn59zsKETQwrPQ37oiQLMDDY5SSLKpxvpZh2u2jTfLdbb: # per-spn.CoinFund.app [AU]


### PR DESCRIPTION
Promoting temporary test node, Zentara, to a Safing node and setting GPS overrides