### PR TITLE
deactivating zentara test node

### DIFF
--- a/spn/main-intel.yaml
+++ b/spn/main-intel.yaml
@@ -218,14 +218,7 @@ Hubs:
     Trusted: true
     VerifiedOwner: Safing
   ZwzsJSTeqcUg3on3P4dMsR7uQsGrvMimrkaJZNv5jj87Zn: # zentara [DE]
-    Trusted: true
-    VerifiedOwner: Safing
-    Override:
-      CountryCode: DE
-      Coordinates: # Dusseldorf
-        Latitude: 51.22
-        Longitude: 6.78
-        AccuracyRadius: 20
+    Discontinued: true
 
   # CoinFund.app
   Zwn59zsKETQwrPQ37oiQLMDDY5SSLKpxvpZh2u2jTfLdbb: # per-spn.CoinFund.app [AU]


### PR DESCRIPTION
deactivating zentara SPN node which was used to test and document process if bringing up and running an SPN node.